### PR TITLE
Fix buzhash to not drop small tail blocks.

### DIFF
--- a/buzhash.go
+++ b/buzhash.go
@@ -67,7 +67,7 @@ func (b *Buzhash) NextBytes() ([]byte, error) {
 			state = state ^ bytehash[b.buf[i]]
 		}
 
-                // Scan through the data for a break point.
+		// Scan through the data for a break point.
 		max := b.n - 32 - 1
 		buf := b.buf
 		bufshf := b.buf[32:]


### PR DESCRIPTION
This fixes buzhash to not drop up to 3 blocks at the end of a file. With buzMax 4x as big as buzMin, there can be up to 4 blocks in the last data from the io.ReadFull() that gives us the EOF. The previous code would only return the first of these blocks and then return the EOF error on the next NextBytes() call, dropping any remaining blocks.

This now makes NextBytes() keep returning blocks after an error from ReadFull() until the buffer is empty. After the buffer is empty, the next NextBytes() call will return the final error.